### PR TITLE
feat: migrate conversation ID headers to native placeholder system

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -650,15 +650,12 @@ class OpenAIClient extends BaseClient {
     const { headers } = this.options;
     if (headers && typeof headers === 'object' && !Array.isArray(headers)) {
       configOptions.baseOptions = {
-        headers: {
-          ...resolveHeaders({
-            headers: {
-              ...headers,
-              ...configOptions?.baseOptions?.headers,
-            },
-          }),
-          ...(this.conversationId && { 'x-conversation-id': this.conversationId })
-        },
+        headers: resolveHeaders({
+          headers: {
+            ...headers,
+            ...configOptions?.baseOptions?.headers,
+          },
+        }),
       };
     }
 

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -610,18 +610,6 @@ class AgentClient extends BaseClient {
 
   /** @type {sendCompletion} */
   async sendCompletion(payload, opts = {}) {
-    // Add conversationId header after BaseClient has set this.conversationId
-    // but before calling chatCompletion which creates the LangChain client
-    if (this.conversationId && this.options.agent.model_parameters?.configuration) {
-      if (!this.options.agent.model_parameters.configuration.defaultHeaders) {
-        this.options.agent.model_parameters.configuration.defaultHeaders = {};
-      }
-      this.options.agent.model_parameters.configuration.defaultHeaders['x-conversation-id'] = this.conversationId;
-      logger.info('[AgentClient] Added x-conversation-id header to agent config: ' + this.conversationId);
-    } else {
-      logger.info('[AgentClient] Could not add x-conversation-id header - conversationId: ' + this.conversationId + ', config exists: ' + !!this.options.agent.model_parameters?.configuration);
-    }
-
     await this.chatCompletion({
       payload,
       onProgress: opts.onProgress,


### PR DESCRIPTION
- Remove custom x-conversation-id header injection from OpenAIClient.js
- Remove custom x-conversation-id header injection from AgentClient.js
- Restore both files to upstream v0.8.0-rc4 state
- Leverage LibreChat's native {{LIBRECHAT_BODY_CONVERSATIONID}} placeholder support

BREAKING CHANGE: Custom endpoints and agents must now configure conversation ID headers using {{LIBRECHAT_BODY_CONVERSATIONID}} placeholders instead of automatic injection

# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
